### PR TITLE
Calculate bytes with getAmountPerUnit

### DIFF
--- a/src/main/java/io/github/projectet/ae2things/command/Command.java
+++ b/src/main/java/io/github/projectet/ae2things/command/Command.java
@@ -69,6 +69,7 @@ public class Command {
 
             nbt.putUUID(Constants.DISKUUID, uuid);
             nbt.putLong(DISKCellInventory.ITEM_COUNT_TAG, AE2Things.STORAGE_INSTANCE.getOrCreateDisk(uuid).itemCount);
+            nbt.putLong(DISKCellInventory.ITEM_BYTES_TAG, AE2Things.STORAGE_INSTANCE.getOrCreateDisk(uuid).itemByte);
             stack.setTag(nbt);
 
             player.addItem(stack);

--- a/src/main/java/io/github/projectet/ae2things/mixin/CursedInternalSlotMixin.java
+++ b/src/main/java/io/github/projectet/ae2things/mixin/CursedInternalSlotMixin.java
@@ -39,6 +39,7 @@ public abstract class CursedInternalSlotMixin {
             UUID id = UUID.randomUUID();
             newStack.getOrCreateTag().putUUID(Constants.DISKUUID, id);
             newStack.getOrCreateTag().putLong(DISKCellInventory.ITEM_COUNT_TAG, storage.itemCount);
+            newStack.getOrCreateTag().putLong(DISKCellInventory.ITEM_BYTES_TAG, storage.itemByte);
             AE2Things.STORAGE_INSTANCE.updateDisk(id, storage);
 
             newStack.setCount(newStack.getMaxStackSize());

--- a/src/main/java/io/github/projectet/ae2things/storage/DISKCellHandler.java
+++ b/src/main/java/io/github/projectet/ae2things/storage/DISKCellHandler.java
@@ -37,7 +37,7 @@ public class DISKCellHandler implements ICellHandler {
         if (handler.hasDiskUUID()) {
             lines.add(Component.literal("Disk UUID: ").withStyle(ChatFormatting.GRAY)
                     .append(Component.literal(handler.getDiskUUID().toString()).withStyle(ChatFormatting.AQUA)));
-            lines.add(Tooltips.bytesUsed(handler.getNbtItemCount(), handler.getTotalBytes()));
+            lines.add(Tooltips.bytesUsed(handler.getNbtItemByte(), handler.getTotalBytes()));
         }
 
         if (handler.isPreformatted()) {

--- a/src/main/java/io/github/projectet/ae2things/util/DataStorage.java
+++ b/src/main/java/io/github/projectet/ae2things/util/DataStorage.java
@@ -13,17 +13,20 @@ public class DataStorage {
     public ListTag stackKeys;
     public long[] stackAmounts;
     public long itemCount;
+    public long itemByte;
 
     public DataStorage() {
         stackKeys = new ListTag();
         stackAmounts = new long[0];
         itemCount = 0;
+        itemByte = 0;
     }
 
-    public DataStorage(ListTag stackKeys, long[] stackAmounts, long itemCount) {
+    public DataStorage(ListTag stackKeys, long[] stackAmounts, long itemCount, long itemByte) {
         this.stackKeys = stackKeys;
         this.stackAmounts = stackAmounts;
         this.itemCount = itemCount;
+        this.itemByte = itemByte;
     }
 
     public CompoundTag toNbt() {
@@ -33,16 +36,23 @@ public class DataStorage {
         if (itemCount != 0)
             nbt.putLong(DISKCellInventory.ITEM_COUNT_TAG, itemCount);
 
+        if (itemByte != 0)
+            nbt.putLong(DISKCellInventory.ITEM_BYTES_TAG, itemByte);
+
         return nbt;
     }
 
     public static DataStorage fromNbt(CompoundTag nbt) {
         long itemCount = 0;
+        long itemByte = 0;
         ListTag stackKeys = nbt.getList(DISKCellInventory.STACK_KEYS, Tag.TAG_COMPOUND);
         long[] stackAmounts = nbt.getLongArray(DISKCellInventory.STACK_AMOUNTS);
         if (nbt.contains(DISKCellInventory.ITEM_COUNT_TAG))
             itemCount = nbt.getLong(DISKCellInventory.ITEM_COUNT_TAG);
 
-        return new DataStorage(stackKeys, stackAmounts, itemCount);
+        if (nbt.contains(DISKCellInventory.ITEM_BYTES_TAG))
+            itemByte = nbt.getLong(DISKCellInventory.ITEM_BYTES_TAG);
+
+        return new DataStorage(stackKeys, stackAmounts, itemCount, itemByte);
     }
 }


### PR DESCRIPTION
This fixed https://github.com/the9grounds/AE-Additions/issues/141

Add new Tag `ITEM_BYTES_TAG ` to track usage bytes. Normally fluids and chemical disk should use 1 byte pre 1k unit

